### PR TITLE
bumping versions and fix test case failing on windows

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,10 +17,10 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
+		<maven.compiler.source>17</maven.compiler.source>
+		<maven.compiler.target>17</maven.compiler.target>
 		<maven.version>3.3.9</maven.version>
-		<ck.version>0.6.3-SNAPSHOT</ck.version>
+		<ck.version>0.7.1-SNAPSHOT</ck.version>
 	</properties>
 
 	<distributionManagement>
@@ -173,7 +173,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-plugin-plugin</artifactId>
-				<version>3.6.0</version>
+				<version>3.10.1</version>
 				<configuration>
 					<skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
 					<detail>true</detail>

--- a/src/test/java/com/github/mauricioaniche/ck/plugin/CKMetricsMojoTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/plugin/CKMetricsMojoTest.java
@@ -69,9 +69,10 @@ public class CKMetricsMojoTest {
 	}
 
 	private List<CSVRecord> getMetrics(List<String> testDirs, String fname) throws IOException {
-		String fullFileName = testDirs.get(0) + "/" + fname;
+		String fullFileName = testDirs.get(0) + File.separator + fname;
+		String suffixToTest = (new StringBuffer()).append("src").append(File.separator).append("test").append(File.separator).append("java").append(File.separator).append(fname).toString();
 		assertTrue("Unexpected " + fname + " filename: " + fullFileName,
-				fullFileName.endsWith("src/test/java/" + fname));
+				fullFileName.endsWith(suffixToTest));
 		
 		File file = new File(fullFileName);
 		assertTrue("File " + file + " does not exist", file.exists());


### PR DESCRIPTION
- java 17
- ck version 0.7.1
- maven plugin 3.10.1 to avoid unsupported class 61 error
- fix test case which run into path delimiter on windows 